### PR TITLE
Service improvements

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,9 +1,17 @@
+# since the psad service returns output in the form of statistics, instead of the default 'exit 0', we need an alternative to check if it is running
+# the status check below checks if the psad service is running using 'ps aux'; using grep it finds any processes named psad, but filters out the grep process itself (using the brackets [])
+# the exit code for the grep process is used to determine if the service is running or not
+# the restart command is also custom, since by default it restarts using /usr/sbin/psad restart, but this will fail with exit code 1 if psad is already running
 class psad::service inherits psad::params {
-  service { 'psad':
-    ensure => running,
-    hasstatus => true,
-    hasrestart => true,
-    enable => true,
-    require => Class["psad::config"]
-  }
+    service { 'psad':
+        ensure      => running,
+        hasstatus   => true,
+        hasrestart  => true,
+        enable      => true,
+        path        => '/bin:/sbin:/usr/bin:/usr/sbin',
+        status      => 'ps aux | grep "[p]sad"',
+        restart     => 'psad -R',
+        require     => Class["psad::config"],
+    }
+
 }


### PR DESCRIPTION
Hi, first of all, thanks for creating this module! :) Saved me a bunch of time when integrating psad into my puppet agents.

However, I ran into some issues on Ubuntu (14.04 Server LTS) when requiring a restart of the psad service.

For example, when I manually shut down the psad service, running the puppet agent did not automatically restart it.

Also, when PSAD is already running and a configuration file has changed, thus requiring a restart, puppet would not do this correctly because on my system it uses `/usr/sbin/psad restart`, which outputs the following `[*] /usr/sbin/psad process is already running! Exiting.` (exit code 1), and so your config changes are not activated.

Last but not least, the default `service psad status` or `psad -S` (identical) is not the correct way to determine if psad is running, and it can take a long time to perform on a system which has been running for a while and as a result, slows down your puppet run times. I changed this by checking to see if the psad process is running or not and using the exit code of the grep command to determine success or failure. This is much quicker and safer way to determine if PSAD is running or not. PSAD's behaviour, by the way, also causes Ubuntu to think it is not running, while in fact it is. Try a `service --status-all` for example, and then a `psad -S`, the first will tell you it is not running, the second will tell you it is.

Maybe these issues are only related to Ubuntu, I have only tested this on Ubuntu Server 12.04 & 14.04 LTS (64-bit).

The changes I made to the service class fixed the above issues for me so hopefully you will merge them back into your master! :+1: 
