### PR TITLE
Shorten variable name.

### DIFF
--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -3,7 +3,7 @@ class psad::cron (
 ) inherits psad::params {
   if($cronjob_enable == true) {
     cron { 'psad_sigupdates':
-      command  => $signature_update_command,
+      command  => $sig_update_cmd,
       user     => root,
       hour     => fqdn_rand(23, 'psad cron hour'),
       minute   => fqdn_rand(59, 'psad cron minute'),

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,7 +5,7 @@ class psad::install inherits psad::params {
   }
 
   exec { 'psad_signature_update':
-    command     => $signature_update_command,
+    command     => $sig_update_cmd,
     returns     => [0,1],
     refreshonly => true
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,7 +30,7 @@ class psad::params {
     }
   }
 
-  $signature_update_command = '/usr/sbin/psad -R;/usr/sbin/psad --sig-update;/usr/sbin/psad -H; > /dev/null 2>&1'
+  $sig_update_cmd = '/usr/sbin/psad -R;/usr/sbin/psad --sig-update;/usr/sbin/psad -H; > /dev/null 2>&1'
 
   $psad_default_config = {
     'email_addresses'            => 'root@localhost',


### PR DESCRIPTION
Closes: https://github.com/tedivm/puppet-psad/issues/7

Before this change, I was getting an error:
```
Syntax error at '=' at .../modules/psad/manifests/params.pp:33:29 on node ...
```
Shortening `$signature_update_command` to `$sig_update_cmd` fixes the problem for me.

Seems like a Puppet bug, perhaps?  I'm using Puppet community version 4.10 on Amazon Linux 2017.03.