### PR TITLE
Add a $manage_package attribute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ will take care of adding it's own required rules in.
 
 ### Setup Requirements
 
-A properly configured firewall is a must- all allowed destinations should be
+A properly configured firewall is a must -- all allowed destinations should be
 explicitly placed into the firewall rules or traffic to them could result in
 blocked hosts.
 
@@ -98,6 +98,23 @@ After setting up your firewall simply include the PSAD class.
 
 ```puppet
 include psad
+```
+
+### What if the PSAD in my repo is old, and I want a newer one?
+
+Install your package before the PSAD class, and set `manage_package => false`:
+
+```puppet
+include psad
+file { $psad_package_local_filename :
+  source => $psad_package_source_url,
+}
+-> package { $psad::package :
+  source => $psad_package_local_filename,
+}
+-> Class { 'psad' :
+  manage_package => false,
+}
 ```
 
 ### How do I change the destination for email notifications?

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,11 +39,11 @@
 # === Examples
 #
 #  class { 'psad' :
-#    $config => {
-#      email_addresses => ['root@localhost.com', 'security@example.com']
+#    config => {
+#      'email_addresses' => ['root@localhost.com', 'security@example.com']
 #    },
-#    firewall_priorty => 850,
-#    cronjob_enable => true
+#    firewall_priority => 850,
+#    cronjob_enable => true,
 #  }
 #
 #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,6 +33,8 @@
 # [*cronjob_enable*]
 #   Set this to add a cronjob to update PSADs signatures daily.
 #
+# [*manage_package*]
+#   Set this to false if you want to manage installation of the psad package separately.
 #
 # === Examples
 #
@@ -59,7 +61,8 @@ class psad (
   $commands = {},
   $firewall_enable = true,
   $firewall_priority = 895,
-  $cronjob_enable = true
+  $cronjob_enable = true,
+  $manage_package = true,
 ) inherits psad::params {
 
   class { 'psad::install':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,13 +1,15 @@
 class psad::install {
   include psad
-  package { $psad::package:
-    ensure => present,
-    notify => Exec['psad_signature_update']
+  if $psad::manage_package {
+    package { $psad::package:
+      ensure => present,
+    }
   }
 
   exec { 'psad_signature_update':
     command     => $psad::signature_update_command,
     returns     => [0,1],
-    refreshonly => true
+    refreshonly => true,
+    subscribe   => Package[$psad::package],
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,11 +1,12 @@
-class psad::install inherits psad::params {
-  package { $psad::install::package:
+class psad::install {
+  include psad
+  package { $psad::package:
     ensure => present,
     notify => Exec['psad_signature_update']
   }
 
   exec { 'psad_signature_update':
-    command     => $signature_update_command,
+    command     => $psad::signature_update_command,
     returns     => [0,1],
     refreshonly => true
   }


### PR DESCRIPTION
This allows users to install a newer `psad` package (e.g. from source or a download package) without maintaining their own repo.